### PR TITLE
Fixed license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2017 Spatie bvba <info@spatie.be>
+Copyright (c) 2016-2017 Spatie bvba <info@spatie.be>
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Valid copyright requires the earliest year to be present, so valid dates are "2016-2017" or just "2016", not "2017".