### PR TITLE
change uppercase function to mb_strtoupper instead of strtoupper

### DIFF
--- a/generator/Console/GenerateCommand.php
+++ b/generator/Console/GenerateCommand.php
@@ -80,7 +80,7 @@ class GenerateCommand extends Command
     protected function emojiToUnicodeHex(string $emoji)
     {
         return '\u{'.implode('}\u{', array_map(function ($hex) {
-            return strtoupper(ltrim($hex, '0'));
+            return mb_strtoupper(ltrim($hex, '0'));
         }, str_split(bin2hex(mb_convert_encoding($emoji, 'UTF-32', 'UTF-8')), 8))).'}';
     }
 

--- a/generator/Emoji.php
+++ b/generator/Emoji.php
@@ -58,8 +58,8 @@ class Emoji implements JsonSerializable, ArrayAccess
         ]);
 
         $this->name = $name;
-        $this->cleanName = strtolower(preg_replace("/\s+/", ' ', preg_replace("/[^\w]+/", ' ', $this->name)));
-        $this->const = 'CHARACTER_'.strtoupper(preg_replace("/\s+/", '', preg_replace('/(.)(?= [a-z0-9])/', '$1_', $this->cleanName)));
+        $this->cleanName = mb_strtolower(preg_replace("/\s+/", ' ', preg_replace("/[^\w]+/", ' ', $this->name)));
+        $this->const = 'CHARACTER_'.mb_strtoupper(preg_replace("/\s+/", '', preg_replace('/(.)(?= [a-z0-9])/', '$1_', $this->cleanName)));
         $this->method = lcfirst(preg_replace("/\s+/", '', ucwords($this->cleanName)));
     }
 

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -6285,7 +6285,7 @@ class Emoji
             throw CouldNotDetermineFlag::countryCodeLenghtIsWrong($countryCode);
         }
 
-        $countryCode = strtoupper($countryCode);
+        $countryCode = mb_strtoupper($countryCode);
 
         return static::encodeCountryCodeLetter($countryCode[0]).static::encodeCountryCodeLetter($countryCode[1]);
     }
@@ -6299,7 +6299,7 @@ class Emoji
     {
         $partialConstantName = static::convertToSnakeCase($characterName);
 
-        $constantName = 'CHARACTER_'.strtoupper($partialConstantName);
+        $constantName = 'CHARACTER_'.mb_strtoupper($partialConstantName);
 
         return $constantName;
     }
@@ -6309,7 +6309,7 @@ class Emoji
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/', '', $value);
 
-            $value = strtolower(preg_replace('/([^0-9])(?=[0-9])/', '$1'.'_', preg_replace('/(.)(?=[A-Z])/', '$1'.'_', $value)));
+            $value = mb_strtolower(preg_replace('/([^0-9])(?=[0-9])/', '$1'.'_', preg_replace('/(.)(?=[A-Z])/', '$1'.'_', $value)));
         }
 
         return $value;


### PR DESCRIPTION
`strtoupper('wavingHand')` returns `WAViNGHAN` when language set to Turkish instead of `WAVINGHAND`.

`Emoji::wavingHand()` or any other emoji with name includes `i` throwing `UnknownCharacter` all the time.

`mb_strtoupper('wavingHand')` workings corrects and returns `WAVINGHAND`.

I did similar fix on `spatie/image` last moth https://github.com/spatie/image/pull/99
