### PR TITLE
Add Emoji::all() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs
 phpunit.xml
 psalm.xml
 vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Or you can use the shorter method by leaving off "character" and using camelCase
 Emoji::grinningFace();
 ```
 
+If you want to get an array containing all emojis, you can use this method:
+```php
+Emoji::all();
+ ```
+
 You can also use an [ISO 3166 Alpha2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code and get the appropriate flag for the country:
 ```php
 Emoji::countryFlag('be'); // 🇧🇪

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -7300,6 +7300,13 @@ class Emoji
         return static::encodeCountryCodeLetter($countryCode[0]).static::encodeCountryCodeLetter($countryCode[1]);
     }
 
+    public static function all(): array
+    {
+        $reflectionClass = new \ReflectionClass(self::class);
+
+        return $reflectionClass->getConstants();
+    }
+
     public static function __callStatic(string $methodName, array $parameters): string
     {
         return static::getCharacter($methodName);

--- a/tests/EmojiTest.php
+++ b/tests/EmojiTest.php
@@ -50,6 +50,23 @@ class EmojiTest extends TestCase
         $this->assertSame('🇦🇦', Emoji::countryFlag('AA'));
     }
 
+    /** @test */
+    public function it_can_return_an_array_of_all_emoji_characters()
+    {
+        $this->assertIsArray(Emoji::all());
+        $this->assertCount(count($this->codeToCallableProvider()), Emoji::all());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider codeToCallableProvider
+     */
+    public function all_emojis_list_will_contain_every_emoji_defined_as_const($name, $code, $cleanName, $const, $method)
+    {
+        $this->assertSame($this->unicodeHexToEmoji($code), Emoji::all()[$const]);
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
I have added a `Emoji::all()` method to get a list of all defined emojis, it could be useful in a `Rule::in(Emoji::all())` validation rule for example :)