### PR TITLE
Fix generate command to create all() static method

### DIFF
--- a/generator/templates/Emoji.twig
+++ b/generator/templates/Emoji.twig
@@ -56,6 +56,13 @@ class Emoji
         return static::encodeCountryCodeLetter($countryCode[0]).static::encodeCountryCodeLetter($countryCode[1]);
     }
 
+    public static function all(): array
+    {
+        $reflectionClass = new \ReflectionClass(self::class);
+
+        return $reflectionClass->getConstants();
+    }
+
     public static function __callStatic(string $methodName, array $parameters): string
     {
         return static::getCharacter($methodName);

--- a/src/Emoji.php
+++ b/src/Emoji.php
@@ -10,7 +10,7 @@ use Spatie\Emoji\Exceptions\UnknownCharacter;
  *
  * @link https://unicode.org/Public/emoji/13.1/emoji-test.txt
  * @version v13.1
- * loaded at: 2020-09-18 00:16:06
+ * loaded at: 2021-06-30 13:43:33
  *
  * ##### Emoji group: SMILEYS & EMOTION #####
  * ##### Emoji subgroup: FACE-SMILING #####


### PR DESCRIPTION
`composer generate` command was not creating the `all()` static method. This PR fixes it :).