### PR TITLE
Updated version reference in README from v13.1 → v15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also use an [ISO 3166 Alpha2](https://en.wikipedia.org/wiki/ISO_3166-1_a
 Emoji::countryFlag('be'); // 🇧🇪
 ```
 
-This package contains Full Emoji List v13.1 based on https://unicode.org/Public/emoji/13.1/emoji-test.txt all methods and constants are auto-generated.
+This package contains Full Emoji List v15.1 based on https://unicode.org/Public/emoji/15.1/emoji-test.txt all methods and constants are auto-generated.
 
 ## Changelog
 


### PR DESCRIPTION
### Summary
Updated version reference in README from v13.1 → v15.1

### Changes
- Updated version reference in README from:
  - v13.1 → v15.1
- Updated linked Unicode source URL from:
  - https://unicode.org/Public/emoji/13.1/emoji-test.txt
  - to https://unicode.org/Public/emoji/15.1/emoji-test.txt

### Impact
- Keeps documentation consistent with the current emoji dataset version used in the package.
- Ensures users reference the correct Unicode standard and source file.

No functional changes to code—documentation update only.
